### PR TITLE
Fixing for months duration

### DIFF
--- a/timex/timex.go
+++ b/timex/timex.go
@@ -53,6 +53,7 @@ func Diff(a, b time.Time) (year, month, day, hour, min, sec int) {
 	if month < 0 {
 		month += 12
 		year--
+		month += 12 * year
 	}
 
 	return


### PR DESCRIPTION
Function returns difference between months of one year of two dates.
Now it returns corrected number of months.